### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,16 @@ setup(
     author_email='isabelle.denghien@cea.fr',
     url='https://github.com/neurospin/unicog',
     packages=find_packages(),
+    install_requires=[
+        'pydicom',
+        'pandas',
+        'mne',
+        'mne-bids',
+        'pydeface',
+        'PyYAML',
+        'bids-validator',
+    ],
+    python_requires='~=3.6',
     package_data=datafiles,
     scripts=['bids/neurospin_to_bids.py'],
     zip_safe=False


### PR DESCRIPTION
Declare dependencies in setup.py to make installation easier (`pip install git+https://github.com/neurospin/unicog.git` works now). Note that I did not test thoroughly that the list of dependencies is complete.